### PR TITLE
Fix company lookup to use name instead of displayName

### DIFF
--- a/src/business-central-client.ts
+++ b/src/business-central-client.ts
@@ -40,7 +40,7 @@ export class BusinessCentralClient {
       return this.companyId;
     }
 
-    const url = `${this.config.serverUrl}/companies?$filter=displayName eq '${this.config.companyName}'`;
+    const url = `${this.config.serverUrl}/companies?$filter=name eq '${this.config.companyName}'`;
     const response = await this.request('GET', url);
 
     if (!response.value || response.value.length === 0) {


### PR DESCRIPTION
## Summary
- Changes company lookup filter from `displayName` to `name` in `getCompanyId()`
- Business Central companies can have an empty `displayName` while having a valid `name`
- Fixes lookup failures for demo companies like CRONUS UK Ltd.

Fixes #4

## Test plan
- [ ] Test with a Business Central sandbox environment using CRONUS UK Ltd.
- [ ] Verify company lookup succeeds when `displayName` is empty but `name` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)