### PR TITLE
Add support for client_credentials authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Model Context Protocol (MCP) server for Microsoft Dynamics 365 Business Central.
 - ✅ **Correct API URLs**: Uses proper `/companies(id)/resource` format (no ODataV4 segment)
 - ✅ **Zero Installation**: Run with `npx` - no pre-installation required
 - ✅ **Azure CLI Auth**: Leverages existing Azure CLI authentication
+- ✅ **Client Credentials Auth**: Service-to-service authentication for AI agents
 - ✅ **Clean Tool Names**: No prefixes, just `get_schema`, `list_items`, etc.
 - ✅ **Full CRUD**: Create, read, update, and delete Business Central records
 
@@ -65,7 +66,10 @@ node build/index.js
 |----------|----------|-------------|---------|
 | `BC_URL_SERVER` | Yes | Business Central API base URL | `https://api.businesscentral.dynamics.com/v2.0/{tenant}/Production/api/v2.0` |
 | `BC_COMPANY` | Yes | Company display name | `KnowAll Ltd` |
-| `BC_AUTH_TYPE` | No | Authentication type (default: `azure_cli`) | `azure_cli` |
+| `BC_AUTH_TYPE` | No | Authentication type (default: `azure_cli`) | `azure_cli` or `client_credentials` |
+| `BC_TENANT_ID` | For client_credentials | Azure AD tenant ID | `00000000-0000-0000-0000-000000000000` |
+| `BC_CLIENT_ID` | For client_credentials | App registration client ID | `00000000-0000-0000-0000-000000000000` |
+| `BC_CLIENT_SECRET` | For client_credentials | App registration client secret | `your-secret-value` |
 
 ### Getting Your Configuration Values
 
@@ -78,12 +82,72 @@ Example URL format:
 https://api.businesscentral.dynamics.com/v2.0/00000000-0000-0000-0000-000000000000/Production/api/v2.0
 ```
 
-## Prerequisites
+## Authentication
 
-- **Azure CLI**: Must be installed and authenticated
-  - Install: https://docs.microsoft.com/cli/azure/install-azure-cli
-  - Login: `az login`
-  - Get token: `az account get-access-token --resource https://api.businesscentral.dynamics.com`
+> **Recommendation**: Use `azure_cli` authentication - it's simpler to set up and more reliable. The `client_credentials` method is also supported but has known configuration challenges with Business Central's Microsoft Entra Applications setup. See [docs/TROUBLESHOOTING.adoc](docs/TROUBLESHOOTING.adoc) for details.
+
+### Option 1: Azure CLI (Recommended)
+
+The simplest and most reliable authentication method. Uses your existing Azure CLI login.
+
+**Prerequisites:**
+- Install Azure CLI: https://docs.microsoft.com/cli/azure/install-azure-cli
+- Login: `az login`
+- Verify access: `az account get-access-token --resource https://api.businesscentral.dynamics.com`
+
+**Configuration:**
+```json
+{
+  "mcpServers": {
+    "business-central": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@knowall-ai/mcp-business-central"],
+      "env": {
+        "BC_AUTH_TYPE": "azure_cli",
+        "BC_URL_SERVER": "https://api.businesscentral.dynamics.com/v2.0/{tenant-id}/Production/api/v2.0",
+        "BC_COMPANY": "My Company"
+      }
+    }
+  }
+}
+```
+
+### Option 2: Client Credentials (Service-to-Service)
+
+For automated systems that need to run without user interaction. This method uses OAuth 2.0 client credentials flow.
+
+> **Note**: This method has known configuration challenges. The Business Central "Microsoft Entra Applications" setup can be complex and the application user creation may not work as expected. See [docs/TROUBLESHOOTING.adoc](docs/TROUBLESHOOTING.adoc) for detailed guidance.
+
+**Setup Overview:**
+
+1. **Create Azure App Registration**:
+   - Go to Azure Portal → Azure Active Directory → App registrations
+   - Create new registration (single tenant)
+   - Add API permission: Dynamics 365 Business Central → `app_access` (Application permission, NOT Delegated)
+   - Grant admin consent for the permission
+   - Add redirect URI: `https://businesscentral.dynamics.com/OAuthLanding.htm`
+
+2. **Generate Client Secret**:
+   - In your app registration, go to Certificates & secrets
+   - Create a new client secret and save it securely
+
+3. **Configure Business Central**:
+   - In Business Central, search for "Microsoft Entra Applications"
+   - Click **+ New** and enter your app's Client ID
+   - Set a Description (this becomes the application user name)
+   - Set State to "Enabled" - you should see "A user named '[Description]' will be created"
+   - Add permission sets: `D365 BUS FULL ACCESS` (recommended) or `D365 READ`
+   - Leave Company field blank for all companies access
+   - Click "Grant Consent"
+
+4. **Verify Setup**:
+   - The application user should appear in the Users list in Business Central
+   - If not, see [docs/TROUBLESHOOTING.adoc](docs/TROUBLESHOOTING.adoc) for solutions
+
+**References**:
+- [Microsoft: Service-to-service authentication](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/administration/automation-apis-using-s2s-authentication)
+- [Business Central API Authentication](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/webservices/authenticate-web-services-using-oauth)
 
 ## Available Tools
 
@@ -202,20 +266,12 @@ Delete an item from Business Central.
 
 ## Troubleshooting
 
-### 401 Unauthorized
-- Ensure Azure CLI is logged in: `az login`
-- Verify you have access to Business Central in your tenant
-- Test token retrieval: `az account get-access-token --resource https://api.businesscentral.dynamics.com`
+See [docs/TROUBLESHOOTING.adoc](docs/TROUBLESHOOTING.adoc) for detailed troubleshooting guides covering:
 
-### Company Not Found
-- Check company name matches exactly (case-sensitive)
-- Verify company exists: Access Business Central web UI
-- Ensure URL includes correct tenant ID and environment
-
-### Resource Not Found
-- Check resource name spelling (e.g., `customers` not `customer`)
-- Some resources may not be available in your Business Central version
-- Use `get_schema` to explore available resources
+- Authentication issues (401 errors, token problems)
+- `client_credentials` setup challenges and known issues
+- Company not found errors
+- Environment-specific configuration (Production vs Sandbox)
 
 ## Development
 

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -1,0 +1,236 @@
+= Troubleshooting Guide: Business Central MCP Server
+:toc:
+:toc-placement!:
+
+toc::[]
+
+== Authentication Methods
+
+=== Recommended: azure_cli Authentication
+
+The `azure_cli` method is the **recommended** authentication approach due to its simplicity and reliability. It uses your existing Azure CLI login session.
+
+**Advantages:**
+* Simple setup - just `az login`
+* Reliable authentication
+* Uses your existing Business Central user and permissions
+
+**Disadvantages:**
+* Requires a user with Business Central license
+* Requires Azure CLI to be installed and logged in
+* Token expires and needs refresh (handled automatically by Azure CLI)
+
+=== Experimental: client_credentials Authentication
+
+The `client_credentials` OAuth flow is designed for service-to-service scenarios where no user interaction is possible. However, **we have encountered significant configuration challenges** with this method.
+
+WARNING: The `client_credentials` setup has known issues with Business Central's "Microsoft Entra Applications" configuration. The application user may not be created properly despite following Microsoft's documentation. Use `azure_cli` if possible.
+
+== client_credentials Issues and Troubleshooting
+
+The `client_credentials` method theoretically doesn't require a per-user license, but setup can be complex and may not work as expected.
+
+==== Common Error: "Authentication_InvalidCredentials"
+
+[source]
+----
+{"error":{"code":"Authentication_InvalidCredentials","message":"Web service call failed because user could not be authenticated or authorized."}}
+----
+
+This error typically means the application user wasn't properly created in Business Central.
+
+==== Setup Checklist
+
+===== 1. Azure App Registration
+
+. Go to https://portal.azure.com[Azure Portal] → App registrations → New registration
+. Note the **Application (client) ID** and **Directory (tenant) ID**
+. Go to **Certificates & secrets** → New client secret (save the value!)
+. Go to **API permissions** → Add a permission → APIs my organization uses
+. Search for "Dynamics 365 Business Central" and select it
+. Select **Application permissions** (NOT Delegated)
+. Add `app_access` permission
+. Click **Grant admin consent for [your tenant]**
+. Go to **Authentication** → Add redirect URI:
++
+[source]
+----
+https://businesscentral.dynamics.com/OAuthLanding.htm
+----
+
+===== 2. Business Central Configuration
+
+. In Business Central, search for **"Microsoft Entra Applications"**
+. Click **+ New**
+. Enter the **Client ID** from your Azure app registration
+. Set a **Description** (e.g., "MCP Business Central API")
+. Set **State** to **Enabled**
++
+[IMPORTANT]
+====
+You should see a message: "A user named '[Description]' will be created"
+====
+. Add **User Permission Sets**:
+** `D365 BUS FULL ACCESS` (recommended) or `D365 READ` for read-only
+** Leave **Company** field blank for all companies, or specify a company
+. Click **Grant Consent**
+
+===== 3. Verify User Creation
+
+After enabling the Microsoft Entra Application:
+
+. Go to **Users** in Business Central
+. The application user (matching your Description) should appear
+. If it doesn't appear, try:
+** Disable and re-enable the State
+** Click Grant Consent again
+** Check the Application Event Log for errors
+
+==== Known Issues
+
+===== Application User Not Created
+
+**Symptom:** The Microsoft Entra Application shows a User ID, but the user doesn't appear in the Users list.
+
+**Possible Causes:**
+
+* Grant Consent didn't complete successfully
+* Azure AD sync delay (wait 2-3 minutes)
+* Missing redirect URI in Azure app registration
+* Tenant-specific configuration issue
+
+**Solutions to Try:**
+
+. Ensure redirect URI `https://businesscentral.dynamics.com/OAuthLanding.htm` is configured in Azure
+. In BC, disable the app → Save → Enable the app → Save → Grant Consent
+. Delete the Microsoft Entra Application entry and recreate it
+. Check Azure Portal → Enterprise applications → Your app → Users and groups
+. Contact Microsoft support if the issue persists
+
+===== AADSTS65007 Error
+
+[source]
+----
+AADSTS65007: Client '...' required resource access configuration has changed
+----
+
+**Solution:** Wait 2-3 minutes for Azure AD to sync, then try Grant Consent again. If it persists, go to Azure Portal → App registrations → Your app → API permissions → Grant admin consent.
+
+===== App ID Shows All Zeros
+
+If the **App ID** field in Microsoft Entra Applications shows `{00000000-0000-0000-0000-000000000000}`:
+
+* This is normal - the App ID field is for BC extensions, not the Azure app
+* The **Client ID** field should contain your Azure app's Application (client) ID
+
+==== Verifying Your Token
+
+You can verify your token has the correct permissions:
+
+[source,bash]
+----
+# Get a token
+TOKEN=$(curl -s -X POST "https://login.microsoftonline.com/{tenant-id}/oauth2/v2.0/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "client_id={client-id}" \
+  -d "client_secret={client-secret}" \
+  -d "scope=https://api.businesscentral.dynamics.com/.default" | jq -r '.access_token')
+
+# Decode and check roles (should include "app_access")
+echo $TOKEN | cut -d'.' -f2 | base64 -d 2>/dev/null | jq '{aud, roles}'
+----
+
+Expected output:
+[source,json]
+----
+{
+  "aud": "https://api.businesscentral.dynamics.com",
+  "roles": ["app_access"]
+}
+----
+
+==== Testing the API Directly
+
+[source,bash]
+----
+# Test with curl
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.businesscentral.dynamics.com/v2.0/{tenant-id}/Production/api/v2.0/companies"
+----
+
+=== azure_cli Authentication (Development/Interactive Use)
+
+The `azure_cli` authentication method uses your Azure CLI login and is simpler to set up.
+
+==== Prerequisites
+
+. Install Azure CLI: https://docs.microsoft.com/cli/azure/install-azure-cli
+. Login: `az login`
+. Verify access: `az account get-access-token --resource https://api.businesscentral.dynamics.com`
+
+==== Common Issues
+
+===== "AADSTS700016: Application not found"
+
+Your Azure CLI may be using a different tenant. Specify the tenant:
+
+[source,bash]
+----
+az login --tenant {tenant-id}
+----
+
+===== Token Expired
+
+Re-authenticate:
+
+[source,bash]
+----
+az login
+----
+
+== Company Not Found
+
+[source]
+----
+Error: Company 'My Company' not found
+----
+
+**Causes:**
+
+* Company name doesn't match exactly (case-sensitive for the `name` field)
+* Using `displayName` instead of `name`
+
+**Solution:**
+
+List companies to find the exact name:
+
+[source,bash]
+----
+# Using azure_cli
+TOKEN=$(az account get-access-token --resource https://api.businesscentral.dynamics.com --query "accessToken" -o tsv)
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://api.businesscentral.dynamics.com/v2.0/{tenant-id}/Production/api/v2.0/companies" | jq '.value[] | {name, displayName}'
+----
+
+Use the `name` field value (not `displayName`) for `BC_COMPANY`.
+
+== Environment-Specific Issues
+
+=== Production vs Sandbox
+
+Microsoft Entra Applications must be configured **separately in each environment**:
+
+* Production: Configure in Production environment
+* Sandbox: Configure in Sandbox environment
+
+The URL changes based on environment:
+
+* Production: `.../v2.0/{tenant-id}/Production/api/v2.0`
+* Sandbox: `.../v2.0/{tenant-id}/Sandbox/api/v2.0`
+
+== References
+
+* https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/administration/automation-apis-using-s2s-authentication[Microsoft: Service-to-Service Authentication]
+* https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/webservices/authenticate-web-services-using-oauth[Microsoft: OAuth Authentication for Web Services]
+* https://www.kauffmann.nl/2021/07/06/service-to-service-authentication-in-business-central-18-3-how-to-set-up/[Kauffmann: S2S Authentication Setup Guide]

--- a/src/business-central-client.ts
+++ b/src/business-central-client.ts
@@ -1,9 +1,13 @@
-import { AzureCliCredential } from '@azure/identity';
+import { AzureCliCredential, ClientSecretCredential, TokenCredential } from '@azure/identity';
 
 export interface BusinessCentralConfig {
   serverUrl: string;
   companyName: string;
-  authType: 'azure_cli';
+  authType: 'azure_cli' | 'client_credentials';
+  // Required for client_credentials auth
+  tenantId?: string;
+  clientId?: string;
+  clientSecret?: string;
 }
 
 export interface Company {
@@ -22,13 +26,22 @@ export interface Company {
 export class BusinessCentralClient {
   private config: BusinessCentralConfig;
   private companyId?: string;
-  private credential?: AzureCliCredential;
+  private credential?: TokenCredential;
 
   constructor(config: BusinessCentralConfig) {
     this.config = config;
 
     if (config.authType === 'azure_cli') {
       this.credential = new AzureCliCredential();
+    } else if (config.authType === 'client_credentials') {
+      if (!config.tenantId || !config.clientId || !config.clientSecret) {
+        throw new Error('client_credentials auth requires tenantId, clientId, and clientSecret');
+      }
+      this.credential = new ClientSecretCredential(
+        config.tenantId,
+        config.clientId,
+        config.clientSecret
+      );
     }
   }
 
@@ -62,6 +75,10 @@ export class BusinessCentralClient {
 
     // Get access token for Business Central
     const tokenResponse = await this.credential.getToken('https://api.businesscentral.dynamics.com/.default');
+
+    if (!tokenResponse) {
+      throw new Error('Failed to acquire access token');
+    }
 
     const headers: Record<string, string> = {
       'Authorization': `Bearer ${tokenResponse.token}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,22 +12,35 @@ import { BusinessCentralClient } from './business-central-client.js';
 const BC_URL_SERVER = process.env.BC_URL_SERVER;
 const BC_COMPANY = process.env.BC_COMPANY;
 const BC_AUTH_TYPE = process.env.BC_AUTH_TYPE || 'azure_cli';
+const BC_TENANT_ID = process.env.BC_TENANT_ID;
+const BC_CLIENT_ID = process.env.BC_CLIENT_ID;
+const BC_CLIENT_SECRET = process.env.BC_CLIENT_SECRET;
 
 if (!BC_URL_SERVER || !BC_COMPANY) {
   console.error('Error: BC_URL_SERVER and BC_COMPANY environment variables are required');
   process.exit(1);
 }
 
-if (BC_AUTH_TYPE !== 'azure_cli') {
-  console.error('Error: Only azure_cli authentication is currently supported');
+if (BC_AUTH_TYPE !== 'azure_cli' && BC_AUTH_TYPE !== 'client_credentials') {
+  console.error('Error: BC_AUTH_TYPE must be either "azure_cli" or "client_credentials"');
   process.exit(1);
+}
+
+if (BC_AUTH_TYPE === 'client_credentials') {
+  if (!BC_TENANT_ID || !BC_CLIENT_ID || !BC_CLIENT_SECRET) {
+    console.error('Error: BC_TENANT_ID, BC_CLIENT_ID, and BC_CLIENT_SECRET are required for client_credentials authentication');
+    process.exit(1);
+  }
 }
 
 // Create Business Central client
 const bcClient = new BusinessCentralClient({
   serverUrl: BC_URL_SERVER,
   companyName: BC_COMPANY,
-  authType: BC_AUTH_TYPE
+  authType: BC_AUTH_TYPE as 'azure_cli' | 'client_credentials',
+  tenantId: BC_TENANT_ID,
+  clientId: BC_CLIENT_ID,
+  clientSecret: BC_CLIENT_SECRET,
 });
 
 // Create MCP server


### PR DESCRIPTION
## Summary

- Adds `client_credentials` OAuth 2.0 authentication for service-to-service scenarios
- Supports `BC_TENANT_ID`, `BC_CLIENT_ID`, `BC_CLIENT_SECRET` environment variables
- Recommends `azure_cli` auth due to known issues with Business Central's Microsoft Entra Applications setup
- Adds comprehensive troubleshooting documentation

## Changes

- `src/business-central-client.ts` - Added `ClientSecretCredential` from `@azure/identity`
- `src/index.ts` - Added new environment variables and validation
- `README.md` - Updated auth documentation, recommends `azure_cli`
- `docs/TROUBLESHOOTING.adoc` - New detailed troubleshooting guide

## Known Issues

The `client_credentials` setup has configuration challenges with Business Central:
- The application user may not be created in BC despite correct Azure configuration
- See `docs/TROUBLESHOOTING.adoc` for detailed guidance

## Test plan

- [x] Build compiles successfully
- [x] `azure_cli` auth tested and working
- [x] `client_credentials` token acquisition works
- [ ] `client_credentials` BC API access (blocked by BC configuration issue)

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)