### PR TITLE
Add Basic Authentication support for on-premises Business Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Model Context Protocol (MCP) server for Microsoft Dynamics 365 Business Central.
 - ✅ **Zero Installation**: Run with `npx` - no pre-installation required
 - ✅ **Azure CLI Auth**: Leverages existing Azure CLI authentication
 - ✅ **Client Credentials Auth**: Service-to-service authentication for AI agents
+- ✅ **Basic Auth**: Username/password authentication for on-premises servers
 - ✅ **Clean Tool Names**: No prefixes, just `get_schema`, `list_items`, etc.
 - ✅ **Full CRUD**: Create, read, update, and delete Business Central records
 
@@ -66,10 +67,12 @@ node build/index.js
 |----------|----------|-------------|---------|
 | `BC_URL_SERVER` | Yes | Business Central API base URL | `https://api.businesscentral.dynamics.com/v2.0/{tenant}/Production/api/v2.0` |
 | `BC_COMPANY` | Yes | Company display name | `KnowAll Ltd` |
-| `BC_AUTH_TYPE` | No | Authentication type (default: `azure_cli`) | `azure_cli` or `client_credentials` |
+| `BC_AUTH_TYPE` | No | Authentication type (default: `azure_cli`) | `azure_cli`, `client_credentials`, or `basic` |
 | `BC_TENANT_ID` | For client_credentials | Azure AD tenant ID | `00000000-0000-0000-0000-000000000000` |
 | `BC_CLIENT_ID` | For client_credentials | App registration client ID | `00000000-0000-0000-0000-000000000000` |
 | `BC_CLIENT_SECRET` | For client_credentials | App registration client secret | `your-secret-value` |
+| `BC_USERNAME` | For basic | Business Central username | `admin` |
+| `BC_PASSWORD` | For basic | Business Central web service access key or password | `your-password` |
 
 ### Getting Your Configuration Values
 
@@ -84,7 +87,7 @@ https://api.businesscentral.dynamics.com/v2.0/00000000-0000-0000-0000-0000000000
 
 ## Authentication
 
-> **Recommendation**: Use `azure_cli` authentication - it's simpler to set up and more reliable. The `client_credentials` method is also supported but has known configuration challenges with Business Central's Microsoft Entra Applications setup. See [docs/TROUBLESHOOTING.adoc](docs/TROUBLESHOOTING.adoc) for details.
+> **Recommendation**: For cloud (SaaS), use `azure_cli` authentication - it's simpler to set up and more reliable. For on-premises Business Central servers, use `basic` authentication. The `client_credentials` method is also supported but has known configuration challenges with Business Central's Microsoft Entra Applications setup. See [docs/TROUBLESHOOTING.adoc](docs/TROUBLESHOOTING.adoc) for details.
 
 ### Option 1: Azure CLI (Recommended)
 
@@ -148,6 +151,43 @@ For automated systems that need to run without user interaction. This method use
 **References**:
 - [Microsoft: Service-to-service authentication](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/administration/automation-apis-using-s2s-authentication)
 - [Business Central API Authentication](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/webservices/authenticate-web-services-using-oauth)
+
+### Option 3: Basic Authentication (On-Premises)
+
+For on-premises Business Central servers that use Windows or NavUserPassword authentication. This method sends a username and password (or web service access key) with each request using HTTP Basic authentication.
+
+**Prerequisites:**
+- A Business Central on-premises server with Basic authentication enabled in the server configuration
+- A valid Business Central user account
+- A web service access key (recommended) or password for the user
+
+**Setup:**
+
+1. In Business Central, navigate to the **Users** page and select the user account
+2. Generate a **Web Service Access Key** (recommended over using the user's password)
+3. Ensure the user has appropriate permission sets assigned
+
+**Configuration:**
+```json
+{
+  "mcpServers": {
+    "business-central": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@knowall-ai/mcp-business-central"],
+      "env": {
+        "BC_AUTH_TYPE": "basic",
+        "BC_URL_SERVER": "https://your-bc-server:7048/BC/api/v2.0",
+        "BC_COMPANY": "My Company",
+        "BC_USERNAME": "admin",
+        "BC_PASSWORD": "your-web-service-access-key"
+      }
+    }
+  }
+}
+```
+
+> **Note**: The server URL for on-premises typically follows the format `https://{server}:{port}/{instance}/api/v2.0`. The default OData port is 7048. Consult your Business Central server administrator for the exact URL.
 
 ## Available Tools
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knowall-ai/mcp-business-central",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knowall-ai/mcp-business-central",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -18,7 +18,15 @@ startCommand:
       bcAuthType:
         type: string
         default: azure_cli
-        description: Authentication type (currently only azure_cli is supported).
+        description: Authentication type (azure_cli, client_credentials, or basic).
+      bcUsername:
+        type: string
+        default: ""
+        description: Username for basic authentication (on-premises).
+      bcPassword:
+        type: string
+        default: ""
+        description: Password or web service access key for basic authentication (on-premises).
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-
@@ -27,5 +35,7 @@ startCommand:
       if (config.bcServerUrl) env.BC_URL_SERVER = config.bcServerUrl;
       if (config.bcCompany) env.BC_COMPANY = config.bcCompany;
       if (config.bcAuthType) env.BC_AUTH_TYPE = config.bcAuthType;
+      if (config.bcUsername) env.BC_USERNAME = config.bcUsername;
+      if (config.bcPassword) env.BC_PASSWORD = config.bcPassword;
       return {command: 'node', args: ['build/index.js'], env};
     }

--- a/src/business-central-client.ts
+++ b/src/business-central-client.ts
@@ -3,11 +3,14 @@ import { AzureCliCredential, ClientSecretCredential, TokenCredential } from '@az
 export interface BusinessCentralConfig {
   serverUrl: string;
   companyName: string;
-  authType: 'azure_cli' | 'client_credentials';
+  authType: 'azure_cli' | 'client_credentials' | 'basic';
   // Required for client_credentials auth
   tenantId?: string;
   clientId?: string;
   clientSecret?: string;
+  // Required for basic auth (on-prem)
+  username?: string;
+  password?: string;
 }
 
 export interface Company {
@@ -27,6 +30,7 @@ export class BusinessCentralClient {
   private config: BusinessCentralConfig;
   private companyId?: string;
   private credential?: TokenCredential;
+  private basicAuthHeader?: string;
 
   constructor(config: BusinessCentralConfig) {
     this.config = config;
@@ -42,6 +46,11 @@ export class BusinessCentralClient {
         config.clientId,
         config.clientSecret
       );
+    } else if (config.authType === 'basic') {
+      if (!config.username || !config.password) {
+        throw new Error('basic auth requires username and password');
+      }
+      this.basicAuthHeader = `Basic ${Buffer.from(`${config.username}:${config.password}`).toString('base64')}`;
     }
   }
 
@@ -69,19 +78,22 @@ export class BusinessCentralClient {
    * Make an authenticated request to Business Central API
    */
   private async request(method: string, url: string, body?: any): Promise<any> {
-    if (!this.credential) {
+    let authHeader: string;
+
+    if (this.basicAuthHeader) {
+      authHeader = this.basicAuthHeader;
+    } else if (this.credential) {
+      const tokenResponse = await this.credential.getToken('https://api.businesscentral.dynamics.com/.default');
+      if (!tokenResponse) {
+        throw new Error('Failed to acquire access token');
+      }
+      authHeader = `Bearer ${tokenResponse.token}`;
+    } else {
       throw new Error('Authentication not configured');
     }
 
-    // Get access token for Business Central
-    const tokenResponse = await this.credential.getToken('https://api.businesscentral.dynamics.com/.default');
-
-    if (!tokenResponse) {
-      throw new Error('Failed to acquire access token');
-    }
-
     const headers: Record<string, string> = {
-      'Authorization': `Bearer ${tokenResponse.token}`,
+      'Authorization': authHeader,
       'Content-Type': 'application/json',
       'Accept': 'application/json'
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,16 @@ const BC_AUTH_TYPE = process.env.BC_AUTH_TYPE || 'azure_cli';
 const BC_TENANT_ID = process.env.BC_TENANT_ID;
 const BC_CLIENT_ID = process.env.BC_CLIENT_ID;
 const BC_CLIENT_SECRET = process.env.BC_CLIENT_SECRET;
+const BC_USERNAME = process.env.BC_USERNAME;
+const BC_PASSWORD = process.env.BC_PASSWORD;
 
 if (!BC_URL_SERVER || !BC_COMPANY) {
   console.error('Error: BC_URL_SERVER and BC_COMPANY environment variables are required');
   process.exit(1);
 }
 
-if (BC_AUTH_TYPE !== 'azure_cli' && BC_AUTH_TYPE !== 'client_credentials') {
-  console.error('Error: BC_AUTH_TYPE must be either "azure_cli" or "client_credentials"');
+if (BC_AUTH_TYPE !== 'azure_cli' && BC_AUTH_TYPE !== 'client_credentials' && BC_AUTH_TYPE !== 'basic') {
+  console.error('Error: BC_AUTH_TYPE must be "azure_cli", "client_credentials", or "basic"');
   process.exit(1);
 }
 
@@ -33,14 +35,23 @@ if (BC_AUTH_TYPE === 'client_credentials') {
   }
 }
 
+if (BC_AUTH_TYPE === 'basic') {
+  if (!BC_USERNAME || !BC_PASSWORD) {
+    console.error('Error: BC_USERNAME and BC_PASSWORD are required for basic authentication');
+    process.exit(1);
+  }
+}
+
 // Create Business Central client
 const bcClient = new BusinessCentralClient({
   serverUrl: BC_URL_SERVER,
   companyName: BC_COMPANY,
-  authType: BC_AUTH_TYPE as 'azure_cli' | 'client_credentials',
+  authType: BC_AUTH_TYPE as 'azure_cli' | 'client_credentials' | 'basic',
   tenantId: BC_TENANT_ID,
   clientId: BC_CLIENT_ID,
   clientSecret: BC_CLIENT_SECRET,
+  username: BC_USERNAME,
+  password: BC_PASSWORD,
 });
 
 // Create MCP server


### PR DESCRIPTION
## Summary
This PR adds support for HTTP Basic authentication to enable the MCP server to connect to on-premises Business Central servers. Previously, only Azure CLI and client credentials authentication methods were supported, limiting usage to cloud-based deployments.

## Key Changes
- **Authentication Method**: Added `basic` as a new authentication type alongside existing `azure_cli` and `client_credentials` options
- **Configuration**: Added two new environment variables:
  - `BC_USERNAME`: Business Central username
  - `BC_PASSWORD`: Web service access key or password
- **Client Implementation**: Updated `BusinessCentralClient` to handle Basic auth by encoding credentials in Base64 and setting the Authorization header
- **Validation**: Added environment variable validation to ensure required credentials are provided when using basic auth
- **Documentation**: 
  - Updated README with basic auth configuration examples
  - Added comprehensive setup instructions for on-premises servers
  - Updated authentication recommendation to guide users based on deployment type (cloud vs on-premises)
- **Smithery Config**: Added UI configuration fields for username and password in `smithery.yaml`
- **Version Bump**: Updated package version from 0.1.1 to 0.1.2

## Implementation Details
- Basic auth header is computed once during client initialization and reused for all requests, avoiding repeated encoding
- The implementation follows the same pattern as token-based auth, with a unified request method that handles both authentication types
- On-premises server URLs typically use port 7048 with format: `https://{server}:{port}/{instance}/api/v2.0`
- Web service access keys are recommended over passwords for improved security

https://claude.ai/code/session_01KhpN4Ho9C1xWtYPJhhygZe