### PR TITLE
Add client_credentials auth for AI agents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knowall-ai/mcp-business-central",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knowall-ai/mcp-business-central",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knowall-ai/mcp-business-central",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Model Context Protocol server for Microsoft Dynamics 365 Business Central",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Adds `client_credentials` authentication support for service-to-service access (AI agents on VMs without interactive login)
- Bumps version to 0.1.3

## Test plan
- [ ] Verify `azure_cli` auth still works
- [ ] Test `client_credentials` auth with BC_TENANT_ID, BC_CLIENT_ID, BC_CLIENT_SECRET env vars
- [ ] Confirm company lookup works with both auth types

🤖 Generated with [Claude Code](https://claude.com/claude-code)